### PR TITLE
Update linter to support JavaScriptNext mode.

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -17,11 +17,11 @@ class ESLint(Linter):
 
     """Provides an interface to the eslint executable."""
 
-    syntax = ('javascript', 'html')
+    syntax = ('javascript', 'html', 'javascriptnext')
     cmd = 'eslint --format=compact'
     version_args = '--version'
     version_re = r'v(?P<version>\d+\.\d+\.\d+)'
-    version_requirement = '>= 0.3.0' 
+    version_requirement = '>= 0.3.0'
     regex = (
         r'^.+?: line (?P<line>\d+), col (?P<col>\d+), '
         r'(?:(?P<error>Error)|(?P<warning>Warning)) - '


### PR DESCRIPTION
Add support for the (ES6) JavaScriptNext syntax mode. https://github.com/Benvie/JavaScriptNext.tmLanguage
