### PR TITLE
Add support for fjsx15 scope

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -21,7 +21,7 @@ class ESLint(NodeLinter):
     """Provides an interface to the eslint executable."""
 
     syntax = ('javascript', 'html', 'javascriptnext', 'javascript (babel)',
-              'javascript (jsx)', 'jsx-real', 'Vue Component', 'vue')
+              'javascript (jsx)', 'jsx-real', 'Vue Component', 'vue', 'fjsx15)
     npm_name = 'eslint'
     cmd = ('eslint', '--format', 'compact', '--stdin', '--stdin-filename', '@')
     version_args = '--version'


### PR DESCRIPTION
This scope is used by the [Naomi](https://packagecontrol.io/packages/Naomi) package, which has enhanced syntax highlighting support for Flow, JSX, and ES2015+. It should be considered as javascript code and attempt to lint with eslint.