### PR TITLE
not compatible with vue-eslint-parser

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -39,8 +39,7 @@ class ESLint(NodeLinter):
     )
     line_col_base = (1, 1)
     selectors = {
-        'html': 'source.js.embedded.html',
-        'vue': 'source.js.embedded.html'
+        'html': 'source.js.embedded.html'
     }
 
     def find_errors(self, output):


### PR DESCRIPTION
eslint-vue-plugin now uses [vue-eslint-parser](https://github.com/mysticatea/vue-eslint-parser) which actually allows you to lint the script and template part of a vue file now (i.e. not just script part).