### PR TITLE
Adds `use_global_linter` setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ For general information on how SublimeLinter works with settings, please see [Se
 
 You can configure `eslint` options in the way you would from the command line, with `.eslintrc` files. For more information, see the [eslint docs](https://github.com/nzakas/eslint/wiki).
 
+SublimeLinter-eslint has its own special settings for controlling things such as whether to use a local or global linter, regardless of the presence of `package.json`. Check out settings in `SublimeLinter-eslint.sublime-settings`.
+
 ## FAQ and Troubleshooting
 
 ##### What is my first step to find out what trouble I have?

--- a/SublimeLinter-eslint.sublime-settings
+++ b/SublimeLinter-eslint.sublime-settings
@@ -1,0 +1,3 @@
+{
+  "use_global_linter": true
+}

--- a/linter.py
+++ b/linter.py
@@ -80,6 +80,10 @@ class ESLint(NodeLinter):
     def communicate(self, cmd, code=None):
         """Run an external executable using stdin to pass code and return its output."""
 
+        config = sublime.load_settings('SublimeLinter-eslint.sublime-settings')
+        if config.get('use_global_linter'):
+            cmd = list(ESLint.cmd)
+
         if '__RELATIVE_TO_FOLDER__' in cmd:
 
             relfilename = self.filename


### PR DESCRIPTION
Which overrides local linter regardless of presence of `package.json`. It's nice that classes that extend `NodeLinter` automatically look in `package.json`, which allows `SublimeLinter-eslint` to use the locally installed `eslint`, but this is bad if the locally installed eslint is broken.

This PR provides an escape hatch.

[This is one reason why it breaks sort of frequently](https://github.com/eslint/eslint/issues/6983). It doesn't seem like that eslint issue will be resolved soon.

The better fix to this problem would probably be to modify `NodeLinter`, which would involve a PR against SublimeLinter, but that's a lot trickier as well.