### PR TITLE
Fixes #87: Provide an option to specify if to use the internal parser for html files or not.

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -45,6 +45,21 @@ class ESLint(NodeLinter):
         'html': 'source.js.embedded.html'
     }
 
+    def __init__(self, view, syntax):
+        """Initialize a new NodeLinter instance."""
+        super(ESLint, self).__init__(view, syntax)
+
+        # Now we have the package.json, if any
+        if self.manifest_path:
+            pkg = self.get_manifest()
+            # If eslint-html-plugin is specified, we assume it is in use and
+            # disable our own html selectors.
+            if (('dependencies' in pkg and
+                 'eslint-plugin-html' in pkg['dependencies']) or
+                ('dependencies' in pkg and
+                 'eslint-plugin-html' in pkg['devDependencies'])):
+                self.selectors.pop('html')
+
     def find_errors(self, output):
         """
         Parse errors from linter's output.


### PR DESCRIPTION
Currently the default is to use SublimeLinter to parse html files, prior to them being run through ESLint. However, this causes conflicts if eslint-plugin-html is used, as that also tries to parse the now javascript-only code.

Various projects will likely use eslint-plugin-html by default as part of the ESLint config / automation that can also be run outside of the browser - as can be seen in #87.

Therefore I'm proposing this change to introduce a setting and changing the default to not use SublimeLinter to parse files. This will let SublimeLinter-eslint and eslint-plugin-html work together "out of the box".

Whilst this may be a breaking change for some people, I believe it is the better default - default to using what the tool is supplying and likely set up for a shared code base, but the user can change it back if they really want to just use the internal parser.