### PR TITLE
Added multiline

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -44,6 +44,7 @@ class ESLint(NodeLinter):
     selectors = {
         'html': 'source.js.embedded.html'
     }
+    multiline = True
 
     def find_errors(self, output):
         """


### PR DESCRIPTION
Prevents "SublimeLinter: No match for <_sre.SRE_Pattern object at 0...x>" errors in Sublime Console
Also permits to correctly use eslint setting "ignore_match" (http://www.sublimelinter.com/en/latest/linter_settings.html#ignore-match)