### PR TITLE
switch to using selectors

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -21,7 +21,6 @@ logger = logging.getLogger('SublimeLinter.plugin.eslint')
 class ESLint(NodeLinter):
     """Provides an interface to the eslint executable."""
 
-    syntax = ('javascript', 'html')
     npm_name = 'eslint'
     cmd = ('eslint', '--format', 'compact', '--stdin', '--stdin-filename', '@')
 
@@ -35,8 +34,8 @@ class ESLint(NodeLinter):
         re.DOTALL
     )
     line_col_base = (1, 1)
-    selectors = {
-        'html': 'source.js.embedded.html'
+    defaults = {
+        'selector': 'source.js - meta.attribute-with-value, text.html.basic'
     }
 
     def find_errors(self, output):

--- a/linter.py
+++ b/linter.py
@@ -35,7 +35,7 @@ class ESLint(NodeLinter):
     )
     line_col_base = (1, 1)
     defaults = {
-        'selector': 'source.js - meta.attribute-with-value, text.html.basic'
+        'selector': 'source.js - meta.attribute-with-value'
     }
 
     def find_errors(self, output):


### PR DESCRIPTION
Most of the syntax_map, at least in my old setup, was filled with variants of JavaScript. The best solution moving forwards with this is to start using the selectors feature here. Perhaps we need to tweak the selector, but at least we're starting somewhere.