### PR TITLE
Fix linter crash for missing ‘ruleId’ on parse errors

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -65,6 +65,7 @@ class ESLint(NodeLinter):
                     continue
 
                 column = match.get('column', None)
+                ruleId = match.get('ruleId', '')
                 if column is not None:
                     # apply line_col_base manually
                     column = column - 1
@@ -73,8 +74,8 @@ class ESLint(NodeLinter):
                     match,
                     match['line'] - 1,  # apply line_col_base manually
                     column,
-                    match['ruleId'] if match['severity'] == 2 else '',
-                    match['ruleId'] if match['severity'] == 1 else '',
+                    ruleId if match['severity'] == 2 else '',
+                    ruleId if match['severity'] == 1 else '',
                     match['message'],
                     None  # near
                 )


### PR DESCRIPTION
ruleId is not included with Parse Errors as seen in the debug output below
`[{'errorCount': 1,
  'filePath': '/test.js',
  'messages': [{'column': 2,
                'fatal': True,
                'line': 101,
                'message': 'Parsing error: Unexpected token',
                'severity': 2}],
  'warningCount': 0}]`
This causes the linter to KeyError, which is especially frustrating when the lint_mode for SublimeLinter is set to 'background'