### PR TITLE
Pretend ' ' for empty views

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -98,3 +98,11 @@ class ESLint(NodeLinter):
             end_column += len(text)
 
         return line, col, end_column
+
+    def run(self, cmd, code):
+        # Workaround eslint bug https://github.com/eslint/eslint/issues/9515
+        # Fixed in eslint 4.10.0
+        if code == '':
+            code = ' '
+
+        return super().run(cmd, code)


### PR DESCRIPTION
eslint < 4.10.0 has a bug where it shows its CLI usage info when
we send the empty string via stdin. The solution here is to send
one space instead.

Tested with the 'no-trailing-spaces' rule to not mark as an error
for such cases.

Proper version branching is maybe over-engineering, and left as
exercise for the reader.

Another solution would be to just check the configuration bc empty
views usually cannot have lint errors. This *could* be done via
`eslint --print-config .`