### PR TITLE
Add step to sanitise command output before parsing

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -53,8 +53,8 @@ class ESLint(NodeLinter):
     def find_errors(self, output):
         """Parse errors from linter's output."""
         try:
-            output_json = output.rstrip().split(os.linesep)[-1]
-            content = json.loads(output_json)
+            last_line = output.rstrip().split(os.linesep)[-1]
+            content = json.loads(last_line)
         except ValueError:
             logger.error(
                 "JSON Decode error: We expected JSON from 'eslint', "


### PR DESCRIPTION
This improves resilience by adding a `_get_output_json` method which will sanitise the ESLint command output before attempting to parse the expected JSON string. Right now, this is a basic operation to select the final line printed, see https://github.com/SublimeLinter/SublimeLinter-eslint/issues/251#issuecomment-394148906.

Fixes #251.