### PR TITLE
Use new `LintMatch`

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -22,7 +22,6 @@ logger = logging.getLogger('SublimeLinter.plugin.eslint')
 class ESLint(NodeLinter):
     """Provides an interface to the eslint executable."""
 
-    npm_name = 'eslint'
     cmd = 'eslint --format json --stdin'
 
     missing_config_regex = re.compile(

--- a/linter.py
+++ b/linter.py
@@ -23,7 +23,7 @@ class ESLint(NodeLinter):
     """Provides an interface to the eslint executable."""
 
     npm_name = 'eslint'
-    cmd = 'eslint --format json --stdin --stdin-filename ${file}'
+    cmd = 'eslint --format json --stdin'
 
     missing_config_regex = re.compile(
         r'^(.*?)\r?\n\w*(ESLint couldn\'t find a configuration file.)',
@@ -31,7 +31,8 @@ class ESLint(NodeLinter):
     )
     line_col_base = (1, 1)
     defaults = {
-        'selector': 'source.js - meta.attribute-with-value'
+        'selector': 'source.js - meta.attribute-with-value',
+        '--stdin-filename': '${file}'
     }
 
     def on_stderr(self, stderr):


### PR DESCRIPTION
- Use the new `LintMatch` to report errors
- Only pass '--stdin-filename' if there is a filename actually
- Remove deprecated 'npm_name' setting