### PR TITLE
Support linting TypeScript .tsx files

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -30,7 +30,7 @@ PLUGINS = {
     'eslint-plugin-json': 'source.json',
     'eslint-plugin-svelte3': 'text.html',
     'eslint-plugin-vue': 'text.html.vue',
-    '@typescript-eslint/parser': 'source.ts',
+    '@typescript-eslint/parser': 'source.ts, source.tsx',
 }
 OPTIMISTIC_SELECTOR = ', '.join({STANDARD_SELECTOR} | set(PLUGINS.values()))
 


### PR DESCRIPTION
TypeScript files might have the `.tsx` filename extension, and we should include them if TypeScript is available too.