### PR TITLE
Add tsdx to list of plugins to detect

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -31,6 +31,7 @@ PLUGINS = {
     'eslint-plugin-svelte3': 'text.html',
     'eslint-plugin-vue': 'text.html.vue',
     '@typescript-eslint/parser': 'source.ts, source.tsx',
+    'tsdx': 'source.ts, source.tsx',
 }
 OPTIMISTIC_SELECTOR = ', '.join({STANDARD_SELECTOR} | set(PLUGINS.values()))
 


### PR DESCRIPTION
This will enable SublimeLinter eslint  on projects utilizing tsdx, a tool wrapper that includes eslint. Unfortunately, tsdx only exposes a human friendly cli to access eslint, however, eslint gets installed alongside any tsdx install, so its safe to use it directly without the tsdx wrapper.

The only thing users would have to do to make this work would be to ensure the .eslintrc file is created, which tsdx can generate using `yarn lint --write-file`.

I'm not a huge user of the tool, but from my local testing, this gets tsdx eslint working with sublime.

Thanks for the fantastic plugins!