### PR TITLE
enable selector-specific stdin filename for buffers

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -22,7 +22,7 @@ from SublimeLinter.lint.base_linter.node_linter import read_json_file
 
 MYPY = False
 if MYPY:
-    from typing import List, Union
+    from typing import List, Optional, Union
 
 
 logger = logging.getLogger('SublimeLinter.plugin.eslint')
@@ -138,7 +138,8 @@ class ESLint(NodeLinter):
         self.notify_unassign()  # Abort linting without popping error dialog
         raise PermanentError()
 
-    def get_stdin_filename(self) -> str | None:
+    def get_stdin_filename(self):
+        # type: () -> Optional[str]
         filename = self.view.file_name()
         if filename is None:
             view_selectors = set(self.view.scope_name(0).split(' '))


### PR DESCRIPTION
Adds logic to use selector specific dummy filenames for unsaved buffers.  Replaces dummy filenames with "stdin" when parsing linter output in the same manner that is currently implemented for "<text>".

Also includes the addition of plugin support for 2 common YAML plugins.  These additions are not core to this change, but are related and necessary to add dummy file extension support for YAML.

A further improvement to this change would be to move the mapping of selectors to file extensions to the config file, but because this is closely coupled to the plugins config, it would make sense to move both to the config file (if possible) at the same time.