### PR TITLE
Add an entry to the FAQ for restarting `eslint_d`

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ touch .eslintrc
 echo '{ "rules": {} }' > .eslintrc
 ```
 
-### I am using `eslint_d` and the linter suddently stops working
+### I use `eslint_d` and the linter suddently stopped working
 
-If you're using `eslint_d` and the linter suddently stops working with an error message like "Error: ENOENT: no such file or directory, open /../eslint/node_modules/globals/index.js", a restart of `eslint_d` might resolve the problem:
+If you use `eslint_d` and the linter suddently stopped working with an error message like "Error: ENOENT: no such file or directory, open /../eslint/node_modules/globals/index.js", a restart of `eslint_d` might resolve the problem:
 
 ```bash
 eslint_d restart

--- a/README.md
+++ b/README.md
@@ -124,3 +124,11 @@ cd $HOME # or cd %HOMEPATH% on Windows
 touch .eslintrc
 echo '{ "rules": {} }' > .eslintrc
 ```
+
+### I am using `eslint_d` and the linter suddently stops working
+
+If you're using `eslint_d` and the linter suddently stops working with an error message like "Error: ENOENT: no such file or directory, open /../eslint/node_modules/globals/index.js", a restart of `eslint_d` might resolve the problem:
+
+```bash
+eslint_d restart
+```


### PR DESCRIPTION
Sometimes the linter can fail with a cryptic error message when `eslint_d` is used, which can be resolved by simply restarting `eslint_d`. Since `eslint_d` is not restarted upon restarting SublimeText, I think it can be worth adding a note to the FAQs to save other people time in debugging.