### PR TITLE
update the scope name for svelte files

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For [Svelte](https://svelte.dev/) `.svelte` files, using [`eslint-plugin-svelte3
 ```json
 "linters": {
     "eslint": {
-        "selector": "text.html, source.js - meta.attribute-with-value"
+        "selector": "text.html.svelte, source.js - meta.attribute-with-value"
     }
 }
 ```


### PR DESCRIPTION
It seems this information is a bit outdated (probably from the svelte2 times, when the usual file extension for svelte components was `.html`). Svelte3 was released 3 or 4 years ago and since then the extension is `.svelte`. No use uses svelte2 anymore.

![Screenshot_2023-03-24_12-40-10](https://user-images.githubusercontent.com/2184309/227524912-235bab30-2637-4c7f-a73d-761481326e90.png)
