### PR TITLE
Escape $ in file paths

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -72,7 +72,7 @@ class ESLint(NodeLinter):
         cmd = ['eslint', '--format=json', '--stdin']
         stdin_filename = self.get_stdin_filename()
         if stdin_filename:
-            cmd.append('--stdin-filename=' + stdin_filename)
+            cmd.append('--stdin-filename=' + stdin_filename.replace('$', '\\$'))
         return cmd
 
     def run(self, cmd, code):


### PR DESCRIPTION
The `$` character in file paths gets treated as a variable by Sublime Text. And as a result, ESLint fails to lint TS files that are "not included" because the path doesn't match any that tsconfig has included.

For example, `/some/long/file.$path.ts` becomes `/some/long/file..ts`

With this change, the `$` is escaped and therefore the full path stays in tact.