### PR TITLE
Use the context object to inject the stdin-filename into the command

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -59,7 +59,7 @@ class ESLint(NodeLinter):
     """Provides an interface to the eslint executable."""
 
     missing_config_regex = re.compile(
-        r'^(.*?)\r?\n\w*(ESLint couldn\'t find a configuration file.)',
+        r"^(.*?)\r?\n\w*(ESLint couldn't find a configuration file.)",
         re.DOTALL
     )
     line_col_base = (1, 1)


### PR DESCRIPTION
If we use SublimeLinter's standard way of injecting variables, we don't
need to watch out for `$` characters because SublineLinter will do.
This is what we did before #326 as well.

This is a follow-up of #331.