### PR TITLE
eslint-plugin-svelte3 -> eslint-plugin-svelte

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ For [Vue.js](https://vuejs.org/) `.vue` files it would be:
 }
 ```
 
-For [Svelte](https://svelte.dev/) `.svelte` files, using [`eslint-plugin-svelte3`](https://github.com/sveltejs/eslint-plugin-svelte3) and [Svelte](https://packagecontrol.io/packages/Svelte) syntax highlighting, it would be:
+For [Svelte](https://svelte.dev/) `.svelte` files, using [`eslint-plugin-svelte`](https://github.com/sveltejs/eslint-plugin-svelte) and [Svelte](https://packagecontrol.io/packages/Svelte) syntax highlighting, it would be:
 
 ```json
 "linters": {

--- a/linter.py
+++ b/linter.py
@@ -41,6 +41,7 @@ PLUGINS = {
     'eslint-plugin-html': 'text.html',
     'eslint-plugin-json': 'source.json',
     'eslint-plugin-svelte': 'text.html',
+    'eslint-plugin-svelte3': 'text.html',
     'eslint-plugin-vue': 'text.html.vue',
     '@angular-eslint/eslint-plugin': 'text.html',
     '@typescript-eslint/parser': 'source.ts, source.tsx',

--- a/linter.py
+++ b/linter.py
@@ -40,7 +40,7 @@ STANDARD_SELECTOR = 'source.js, source.jsx'
 PLUGINS = {
     'eslint-plugin-html': 'text.html',
     'eslint-plugin-json': 'source.json',
-    'eslint-plugin-svelte3': 'text.html',
+    'eslint-plugin-svelte': 'text.html',
     'eslint-plugin-vue': 'text.html.vue',
     '@angular-eslint/eslint-plugin': 'text.html',
     '@typescript-eslint/parser': 'source.ts, source.tsx',


### PR DESCRIPTION
It's deprecated.

In the meantime I'd be more than happy for any pointers how I can make `eslint-plugin-svelte` work locally.