### PR TITLE
Add eslint-plugin-react

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -40,6 +40,7 @@ STANDARD_SELECTOR = 'source.js, source.jsx'
 PLUGINS = {
     'eslint-plugin-html': 'text.html',
     'eslint-plugin-json': 'source.json',
+    'eslint-plugin-react': 'source.js, source.jsx, source.mjs, source.cjs, source.ts, source.tsx',
     'eslint-plugin-svelte': 'text.html',
     'eslint-plugin-svelte3': 'text.html',
     'eslint-plugin-vue': 'text.html.vue',


### PR DESCRIPTION
We just set up ESlint in a React project and SublimeLinter was complaining

> package.json did not contain dependencies or devDependencies required to lint this file type. Manually set 'selector' to override this behavior, or install the required dependencies.

[eslint-plugin-react](https://www.npmjs.com/package/eslint-plugin-react) itself comes with other plugins https://github.com/jsx-eslint/eslint-plugin-react/blob/51d342ba350ae7d7dabce1caa648e71926ef283f/package.json#L58

I got the list of extensions from their example config:

```js
module.exports = [
  …
  {
    files: ['**/*.{js,jsx,mjs,cjs,ts,tsx}'],
  …
];
```