### PR TITLE
@angular-eslint/eslint-plugin can lint ts files

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -44,7 +44,7 @@ PLUGINS = {
     'eslint-plugin-svelte': 'text.html',
     'eslint-plugin-svelte3': 'text.html',
     'eslint-plugin-vue': 'text.html.vue',
-    '@angular-eslint/eslint-plugin': 'text.html',
+    '@angular-eslint/eslint-plugin': 'source.ts, text.html',
     '@typescript-eslint/parser': 'source.ts, source.tsx',
     'tsdx': 'source.ts, source.tsx',
     'eslint-plugin-yml': 'source.yaml',


### PR DESCRIPTION
I had to add this so in my angular project `*.ts` files were linted at all. There is no explicit `@typescript-eslint/parser` dependency needed.