### PR TITLE
Add eslint-plugin-astro

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -38,7 +38,7 @@ logger = logging.getLogger('SublimeLinter.plugin.eslint')
 
 STANDARD_SELECTOR = 'source.js, source.jsx'
 PLUGINS = {
-    'eslint-plugin-astro': 'source.astro, text.html.astro, meta.template.astro, text.html.markdown.jsx',
+    'eslint-plugin-astro': 'source.astro',
     'eslint-plugin-html': 'text.html',
     'eslint-plugin-json': 'source.json',
     'eslint-plugin-react': 'source.js, source.jsx, source.mjs, source.cjs, source.ts, source.tsx',

--- a/linter.py
+++ b/linter.py
@@ -38,6 +38,7 @@ logger = logging.getLogger('SublimeLinter.plugin.eslint')
 
 STANDARD_SELECTOR = 'source.js, source.jsx'
 PLUGINS = {
+    'eslint-plugin-astro': 'source.astro, text.html.astro, meta.template.astro, text.html.markdown.jsx',
     'eslint-plugin-html': 'text.html',
     'eslint-plugin-json': 'source.json',
     'eslint-plugin-react': 'source.js, source.jsx, source.mjs, source.cjs, source.ts, source.tsx',


### PR DESCRIPTION
I'm building an astro website and would like to have it linted using 
https://github.com/ota-meshi/eslint-plugin-astro

I think that this might also be required: https://packagecontrol.io/packages/Astro 
So maybe this isn't the correct way to do this.

In which case, what is the correct way to do this?