### PR TITLE
Add ESM and CommonJS sources to Standard Selector

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -36,7 +36,7 @@ if MYPY:
 logger = logging.getLogger('SublimeLinter.plugin.eslint')
 
 
-STANDARD_SELECTOR = 'source.js, source.jsx'
+STANDARD_SELECTOR = 'source.js, source.jsx, source.mjs, source.cjs'
 PLUGINS = {
     'eslint-plugin-html': 'text.html',
     'eslint-plugin-json': 'source.json',


### PR DESCRIPTION
I think that `.cjs` and `.mjs` are much more common now and should be included in the standard selector